### PR TITLE
Internal SDK Tracing

### DIFF
--- a/src/Sampler.php
+++ b/src/Sampler.php
@@ -57,7 +57,7 @@ class Sampler
     {
         $segment = $trace->startSubsegment('Sampler::getMatchedRule');
 
-        if (($rule = RuleMatcher::matchFirst($trace, $this->samplerCache->getAllSavedRules())) !== null) {
+        if (($rule = RuleMatcher::matchFirst($trace, $this->samplerCache->getAllRules())) !== null) {
             $segment->end();
             return $rule;
         }

--- a/src/Sampler.php
+++ b/src/Sampler.php
@@ -27,10 +27,7 @@ class Sampler
      */
     public function shouldSample(Trace $trace)
     {
-        $segment = (new Segment())
-            ->begin()
-            ->setName('Sampler::shouldSample');
-        $trace->addSubsegment($segment);
+        $segment = $trace->startSubsegment('Sampler::shouldSample');
 
         $now = time();
         // Match the trace against a rule.
@@ -45,6 +42,7 @@ class Sampler
             // TODO: Add a local sampler if we care, general consensus is if we can't load rules, dont sample
             //'No effective centralized sampling rule match. Fallback to local rules.'
             //return this.localSampler.shouldSample(sampleRequest);
+            $segment->end();
             return false;
         }
     }
@@ -57,10 +55,7 @@ class Sampler
      */
     public function getMatchedRule(Trace $trace)
     {
-        $segment = (new Segment())
-            ->begin()
-            ->setName('Sampler::getMatchedRule');
-        $trace->addSubsegment($segment);
+        $segment = $trace->startSubsegment('Sampler::getMatchedRule');
 
         if (($rule = RuleMatcher::matchFirst($trace, $this->samplerCache->getAllRules())) !== null) {
             $segment->end();
@@ -89,10 +84,7 @@ class Sampler
      */
     private function processMatchedRule(Rule $rule, $now, Trace $trace)
     {
-        $segment = (new Segment())
-            ->begin()
-            ->setName('Sampler::processMatchedRule');
-        $trace->addSubsegment($segment);
+        $segment = $trace->startSubsegment('Sampler::processMatchedRule');
 
         //As long as a rule is matched we increment request counter.
         $rule->incrementRequestCount();
@@ -114,7 +106,7 @@ class Sampler
             $sample = false;
         }
 
-        $this->samplerCache->saveRule($rule);
+        $this->samplerCache->saveRule($rule, $trace);
 
         $segment->end();
         return $sample;

--- a/src/Sampler.php
+++ b/src/Sampler.php
@@ -57,7 +57,7 @@ class Sampler
     {
         $segment = $trace->startSubsegment('Sampler::getMatchedRule');
 
-        if (($rule = RuleMatcher::matchFirst($trace, $this->samplerCache->getAllRules())) !== null) {
+        if (($rule = RuleMatcher::matchFirst($trace, $this->samplerCache->getAllSavedRules())) !== null) {
             $segment->end();
             return $rule;
         }
@@ -106,7 +106,7 @@ class Sampler
             $sample = false;
         }
 
-        $this->samplerCache->saveRule($rule, $trace);
+        $this->samplerCache->saveRule($rule);
 
         $segment->end();
         return $sample;

--- a/src/Sampling/RuleMatcher.php
+++ b/src/Sampling/RuleMatcher.php
@@ -2,6 +2,7 @@
 
 namespace Pkerrigan\Xray\Sampling;
 
+use Pkerrigan\Xray\Segment\Segment;
 use Pkerrigan\Xray\Trace;
 use Pkerrigan\Xray\Utils;
 
@@ -20,14 +21,21 @@ class RuleMatcher
      */
     public static function matchFirst(Trace $trace, array $samplingRules)
     {
+        $segment = (new Segment())
+            ->begin()
+            ->setName('RuleMatcher::matchFirst');
+        $trace->addSubsegment($segment);
+
         $samplingRules = Utils::sortSamplingRulesByPriorityDescending($samplingRules);
 
         foreach ($samplingRules as $samplingRule) {
             if (self::match($trace, $samplingRule)) {
+                $segment->end();
                 return $samplingRule;
             }
         }
 
+        $segment->end();
         return null;
     }
 

--- a/src/Sampling/RuleRepository/AwsSdkRuleRepository.php
+++ b/src/Sampling/RuleRepository/AwsSdkRuleRepository.php
@@ -5,6 +5,7 @@ namespace Pkerrigan\Xray\Sampling\RuleRepository;
 use Aws\Exception\AwsException;
 use Aws\XRay\XRayClient;
 use Pkerrigan\Xray\Sampling\Rule;
+use Pkerrigan\Xray\Trace;
 
 /**
  * Retrives sampling rules from the AWS console
@@ -35,6 +36,7 @@ class AwsSdkRuleRepository implements RuleRepository
      */
     public function getAll()
     {
+        $segment = Trace::getInstance()->startSubsegment('AwsSdkRuleRepository::getAll');
         try {
             /** @var Rule[] $samplingRules */
             $samplingRules = [];
@@ -47,10 +49,11 @@ class AwsSdkRuleRepository implements RuleRepository
                     $samplingRules[] = (new Rule())->populateFromAWS($samplingRule['SamplingRule']);
                 }
             }
-
+            $segment->end();
             return $samplingRules;
         } catch (AwsException $ex) {
             if (!empty($this->fallbackSamplingRule)) {
+                $segment->end();
                 return [(new Rule())->populateFromAWS($this->fallbackSamplingRule)];
             }
 

--- a/src/Sampling/RuleRepository/CachedRuleRepository.php
+++ b/src/Sampling/RuleRepository/CachedRuleRepository.php
@@ -4,6 +4,7 @@ namespace Pkerrigan\Xray\Sampling\RuleRepository;
 
 use Pkerrigan\Xray\Sampling\CacheError;
 use Pkerrigan\Xray\Sampling\Rule;
+use Pkerrigan\Xray\Trace;
 use Psr\SimpleCache\CacheInterface;
 use Psr\SimpleCache\InvalidArgumentException;
 
@@ -44,8 +45,12 @@ class CachedRuleRepository implements RuleRepository
      */
     public function getAll()
     {
+        $segment = Trace::getInstance()->startSubsegment('CachedRuleRepository::getAll');
+
         if ($this->cache->has(self::CACHE_KEY)) {
-            return $this->cache->get(self::CACHE_KEY);
+            $samplingRules = $this->cache->get(self::CACHE_KEY);
+            $segment->end();
+            return  $samplingRules;
         }
 
         $samplingRules = $this->samplingRuleRepository->getAll();
@@ -53,6 +58,7 @@ class CachedRuleRepository implements RuleRepository
             throw new CacheError('Failed to save sampling rules to the cache');
         }
 
+        $segment->end();
         return $samplingRules;
     }
 }

--- a/src/Sampling/SamplerCache.php
+++ b/src/Sampling/SamplerCache.php
@@ -46,7 +46,7 @@ class SamplerCache
     public function getAllSavedRules()
     {
         $segment = Trace::getInstance()->startSubsegment('SamplerCache::getAllSavedRules');
-        $rules = $this->stateManager->getAllSavedRulesFromRules($this->ruleRepository->getAll()());
+        $rules = $this->stateManager->getAllSavedRulesFromRules($this->ruleRepository->getAll());
         $segment->end();
         return $rules;
     }

--- a/src/Sampling/SamplerCache.php
+++ b/src/Sampling/SamplerCache.php
@@ -111,7 +111,7 @@ class SamplerCache
     private function shouldUpdateTargets()
     {
         $segment = Trace::getInstance()->startSubsegment('SamplerCache::shouldUpdateTargets');
-        $shouldUpdate = ($this->stateManager->getLastTargetUpdate() + 10) > time();
+        $shouldUpdate = time() > ($this->stateManager->getLastTargetUpdate() + 10);
         $segment->end();
 
         return $shouldUpdate;

--- a/src/Sampling/SamplerCache.php
+++ b/src/Sampling/SamplerCache.php
@@ -43,23 +43,10 @@ class SamplerCache
      * @return Rule[]
      * @throws InvalidArgumentException
      */
-    public function getAllRules()
-    {
-        $segment = Trace::getInstance()->startSubsegment('SamplerCache::getAllRules');
-        $rules = $this->ruleRepository->getAll();
-        $segment->end();
-        return $rules;
-    }
-
-
-    /**
-     * @return Rule[]
-     * @throws InvalidArgumentException
-     */
     public function getAllSavedRules()
     {
         $segment = Trace::getInstance()->startSubsegment('SamplerCache::getAllSavedRules');
-        $rules = $this->stateManager->getAllSavedRulesFromRules($this->ruleRepository->getAll());
+        $rules = $this->stateManager->getAllSavedRulesFromRules($this->ruleRepository->getAll()());
         $segment->end();
         return $rules;
     }

--- a/src/Sampling/SamplerCache.php
+++ b/src/Sampling/SamplerCache.php
@@ -43,7 +43,7 @@ class SamplerCache
      * @return Rule[]
      * @throws InvalidArgumentException
      */
-    public function getAllSavedRules()
+    public function getAllRules()
     {
         $segment = Trace::getInstance()->startSubsegment('SamplerCache::getAllSavedRules');
         $rules = $this->stateManager->getAllSavedRulesFromRules($this->ruleRepository->getAll());
@@ -102,7 +102,7 @@ class SamplerCache
     private function getCandidates()
     {
         $segment = Trace::getInstance()->startSubsegment('SamplerCache::getCandidates');
-        $rules = $this->getAllSavedRules();
+        $rules = $this->getAllRules();
 
         $candidates = [];
         foreach ($rules as $rule) {

--- a/src/Sampling/StateManager.php
+++ b/src/Sampling/StateManager.php
@@ -74,7 +74,6 @@ class StateManager
     public function saveRule(Rule $rule)
     {
         $segment = Trace::getInstance()->startSubsegment('StateManager::saveRule');
-        $rule = $this->getRule($rule->getCacheKey())->merge($rule);
         if (!$this->cache->set($rule->getCacheKey(), $rule)) {
             throw new CacheError("Failed to save rule " . $rule->getName());
         }

--- a/src/Sampling/StateManager.php
+++ b/src/Sampling/StateManager.php
@@ -16,6 +16,7 @@ use Psr\SimpleCache\InvalidArgumentException;
 class StateManager
 {
     const CLIENT_ID_CACHE = 'StateManagerClientID';
+    const LAST_TARGET_UPDATE = 'StateManagerLastTargetUpdate';
 
     /**
      * @var CacheInterface
@@ -25,6 +26,43 @@ class StateManager
     public function __construct(CacheInterface $cache)
     {
         $this->cache = $cache;
+    }
+
+    /**
+     * Gets the timestamp of the last target update
+     * @return int
+     * @throws InvalidArgumentException
+     */
+    public function getLastTargetUpdate()
+    {
+        $segment = Trace::getInstance()->startSubsegment('StateManager::getLastTargetUpdate');
+
+        $rule = null;
+        if ($this->cache->has(self::LAST_TARGET_UPDATE)) {
+            $targetUpdate = $this->cache->get(self::LAST_TARGET_UPDATE);
+            $segment->end();
+            return $targetUpdate;
+        }
+        $segment->end();
+        return 0;
+    }
+
+    /**
+     * Sets the timestamp of the last target update
+     * @param $lastTargetUpdate
+     * @return void
+     * @throws CacheError
+     * @throws InvalidArgumentException
+     */
+    public function setLastTargetUpdate($lastTargetUpdate)
+    {
+        $segment = Trace::getInstance()->startSubsegment('StateManager::setLastTargetUpdate');
+
+        $rule = null;
+        if (!$this->cache->set(self::LAST_TARGET_UPDATE, $lastTargetUpdate)) {
+            throw new CacheError("Failed to save last target update");
+        }
+        $segment->end();
     }
 
 

--- a/src/Sampling/StateManager.php
+++ b/src/Sampling/StateManager.php
@@ -2,6 +2,7 @@
 
 namespace Pkerrigan\Xray\Sampling;
 
+use Pkerrigan\Xray\Trace;
 use Pkerrigan\Xray\Utils;
 use Psr\SimpleCache\CacheInterface;
 use Psr\SimpleCache\InvalidArgumentException;
@@ -35,11 +36,13 @@ class StateManager
      */
     public function updateRule(Rule $rule)
     {
+        $segment = Trace::getInstance()->startSubsegment('StateManager::updateRule');
         if (($oldRule = $this->getRule($rule->getCacheKey())) !== null) {
             $rule = $rule->merge($oldRule);
         }
 
         $this->saveRule($rule);
+        $segment->end();
         return $rule;
     }
 
@@ -51,11 +54,15 @@ class StateManager
      */
     public function getRule($cacheKey)
     {
+        $segment = Trace::getInstance()->startSubsegment('StateManager::getRule');
         $cacheKey = Utils::stripInvalidCharacters($cacheKey);
+
+        $rule = null;
         if ($this->cache->has($cacheKey)) {
-            return $this->cache->get($cacheKey);
+            $rule = $this->cache->get($cacheKey);
         }
-        return null;
+        $segment->end();
+        return $rule;
     }
 
     /**
@@ -66,9 +73,12 @@ class StateManager
      */
     public function saveRule(Rule $rule)
     {
+        $segment = Trace::getInstance()->startSubsegment('StateManager::saveRule');
+        $rule = $this->getRule($rule->getCacheKey())->merge($rule);
         if (!$this->cache->set($rule->getCacheKey(), $rule)) {
             throw new CacheError("Failed to save rule " . $rule->getName());
         }
+        $segment->end();
     }
 
     /**
@@ -76,11 +86,12 @@ class StateManager
      */
     public function getAllSavedRulesFromRules(array $rules)
     {
+        $segment = Trace::getInstance()->startSubsegment('StateManager::getAllSavedRulesFromRules');
         $savedRules = [];
         foreach ($rules as $rule) {
             $savedRules[] = $this->updateRule($rule);
         }
-
+        $segment->end();
         return $savedRules;
     }
 
@@ -93,14 +104,19 @@ class StateManager
      */
     public function getClientInstanceId()
     {
+        $segment = Trace::getInstance()->startSubsegment('StateManager::getClientInstanceId');
+
         if ($this->cache->has(self::CLIENT_ID_CACHE)) {
-            return $this->cache->get(self::CLIENT_ID_CACHE);
+            $clientID = $this->cache->get(self::CLIENT_ID_CACHE);
+            $segment->end();
+            return $clientID;
         }
 
         $clientID = bin2hex(random_bytes(12));
         if (!$this->cache->set(self::CLIENT_ID_CACHE, $clientID)) {
             throw new CacheError("Failed to save client id ${$clientID}");
         }
+        $segment->end();
         return $clientID;
     }
 }

--- a/src/Segment/Segment.php
+++ b/src/Segment/Segment.php
@@ -236,10 +236,6 @@ class Segment implements JsonSerializable
      */
     public function addSubsegment(Segment $subsegment)
     {
-        if (!$this->isOpen()) {
-            return $this;
-        }
-
         $this->subsegments[] = $subsegment;
         $subsegment->setSampled($this->isSampled());
 

--- a/src/Trace.php
+++ b/src/Trace.php
@@ -9,7 +9,7 @@ use Pkerrigan\Xray\Segment\Segment;
 /**
  *
  * @author Patrick Kerrigan (patrickkerrigan.uk)
- * @since 13/05/2018
+ * @since  13/05/2018
  */
 class Trace extends Segment
 {
@@ -19,14 +19,17 @@ class Trace extends Segment
      * @var static
      */
     private static $instance;
+
     /**
      * @var string
      */
     private $serviceVersion;
+
     /**
      * @var string
      */
     private $serviceEnvironment;
+
     /**
      * @var string
      */
@@ -42,6 +45,14 @@ class Trace extends Segment
         }
 
         return self::$instance;
+    }
+
+    /**
+     * @return static
+     */
+    public static function setInstance(Trace $trace)
+    {
+        self::$instance = $trace;
     }
 
     /**
@@ -136,11 +147,27 @@ class Trace extends Segment
 
     /**
      * Helper function to add ECS Plugin data
+     *
      * @return Trace
      */
     public function addECSPlugin()
     {
         return $this->addPluginData(new ECS());
+    }
+
+    /**
+     * Helper function to start a subsegment
+     * @param $name
+     * @return Segment
+     */
+    public function startSubsegment($name)
+    {
+        $segment = (new Segment())
+            ->setName($name)
+            ->begin();
+        $this->addSubsegment($segment);
+
+        return $segment;
     }
 
     /**
@@ -165,10 +192,12 @@ class Trace extends Segment
         $data = parent::jsonSerialize();
 
         $data['http'] = $this->serialiseHttpData();
-        $data['service'] = array_filter([
-            'version' => $this->serviceVersion,
-            'environment' => $this->serviceEnvironment
-        ]);
+        $data['service'] = array_filter(
+            [
+                'version' => $this->serviceVersion,
+                'environment' => $this->serviceEnvironment,
+            ]
+        );
         $data['user'] = $this->user;
 
         return array_filter($data);
@@ -189,12 +218,12 @@ class Trace extends Segment
 
     /**
      * Generates an amazon id.
+     *
      * @return string
      * @throws \Exception
      */
     private function generateId()
     {
-
         $startHex = dechex((int)$this->startTime);
         $uuid = bin2hex(random_bytes(12));
 
@@ -203,6 +232,7 @@ class Trace extends Segment
 
     /**
      * Sets a new generated amazon id.
+     *
      * @throws \Exception
      */
     private function generateTraceId()

--- a/src/Trace.php
+++ b/src/Trace.php
@@ -144,6 +144,20 @@ class Trace extends Segment
     }
 
     /**
+     * @param Segment $subsegment
+     * @return static
+     */
+    public function addSubsegment(Segment $subsegment)
+    {
+        $segment = $this->getCurrentSegment();
+        if ($segment === $this) {
+            return parent::addSubsegment($subsegment);
+        }
+
+        return $segment->addSubsegment($subsegment);
+    }
+
+    /**
      * @inheritdoc
      */
     public function jsonSerialize()

--- a/src/TraceService.php
+++ b/src/TraceService.php
@@ -44,10 +44,8 @@ class TraceService
      */
     public function addSamplingDecision(Trace $trace)
     {
-        $segment = (new Segment())
-            ->begin()
-            ->setName('TraceService::addSamplingDecision');
-        $trace->addSubsegment($segment);
+        Trace::setInstance($trace);
+        $segment = $trace->startSubsegment('TraceService::addSamplingDecision');
 
         // Trace is already sampled.
         // Return true.
@@ -70,11 +68,6 @@ class TraceService
      */
     public function addSamplingDecisionWithRequest(Trace $trace, ServerRequestInterface $request)
     {
-        $segment = (new Segment())
-            ->begin()
-            ->setName('TraceService::addSamplingDecisionWithRequest');
-        $trace->addSubsegment($segment);
-
         $uri = $request->getUri();
         $amazonHeader = $request->getHeaderLine('x-amzn-trace-id');
 
@@ -93,10 +86,7 @@ class TraceService
             return $trace->setSampled(boolval($headerVariables['Sampled']));
         }
 
-        $decision = $this->addSamplingDecision($trace);
-        $segment->end();
-
-        return $decision;
+        return $this->addSamplingDecision($trace);
     }
 
     public function getClientAddress(ServerRequestInterface $request)

--- a/tests/Segment/SegmentTest.php
+++ b/tests/Segment/SegmentTest.php
@@ -152,7 +152,7 @@ class SegmentTest extends TestCase
         );
     }
 
-    public function testAddingSubsegmentToClosedSegmentFails()
+    public function testAddingSubsegmentToClosedSegmentFSucceeds()
     {
         $segment = new Segment();
         $subsegment = new Segment();
@@ -169,7 +169,7 @@ class SegmentTest extends TestCase
 
         $serialised = $segment->jsonSerialize();
 
-        $this->assertArrayNotHasKey('subsegments', $serialised);
+        $this->assertArrayHasKey('subsegments', $serialised);
     }
 
     public function testAddingSubsegmentSetsSampled()


### PR DESCRIPTION
Adding in Internal Tracing for the PHP XRay SDK to ensure that the SDK is not adding in overhead to requests.

This also ensures that the targeting rules are only updated every 10 seconds like the node sdk instead of on every request.