### PR TITLE
changing header

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,3 @@ script:
   - export SYMFONY_PHPUNIT_VERSION=5.7
   - php vendor/bin/simple-phpunit
 
-after_script:
-  - php vendor/bin/php-coveralls -v
-

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,6 @@
 
     "require-dev": {
         "phpunit/phpunit": "^4.8 | ^5.4 | ^6.5 | ^8.5.4",
-        "php-coveralls/php-coveralls": "^2.1.0",
         "symfony/phpunit-bridge": "^5.0",
         "squizlabs/php_codesniffer": "^3.5"
     }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -16,7 +16,4 @@
             <directory suffix=".php">src</directory>
         </whitelist>
     </filter>
-    <logging>
-        <log type="coverage-clover" target="build/logs/clover.xml"/>
-    </logging>
 </phpunit>

--- a/src/Trace.php
+++ b/src/Trace.php
@@ -164,6 +164,8 @@ class Trace extends Segment
     {
         $segment = (new Segment())
             ->setName($name)
+            //All trace ids should be set to that of the trace
+            ->setTraceId($this->getTraceId())
             ->begin();
         $this->addSubsegment($segment);
 
@@ -211,8 +213,11 @@ class Trace extends Segment
      */
     public function getAmazonTraceHeader()
     {
-        return 'Root=' . $this->generateId() . ';' .
-            'Parent=' . $this->getTraceId() . ';' .
+        //There should always be a segment in progress if we are trying to get the amazon trace header
+        //We need the id of the current segment in order to make it the parent.
+        $segment = $this->getCurrentSegment();
+        return 'Root=' . $this->getTraceId() . ';' .
+            'Parent=' . $segment->getId() . ';' .
             'Sampled=' . ($this->isSampled() ? '1' : '0');
     }
 

--- a/tests/TraceTest.php
+++ b/tests/TraceTest.php
@@ -156,6 +156,6 @@ class TraceTest extends TestCase
 
         $newHeader = $trace->getAmazonTraceHeader();
         $this->assertStringStartsWith("Root=", $newHeader);
-        $this->assertStringEndsWith(";Parent=$traceId;Sampled=1", $newHeader);
+        $this->assertStringEndsWith(";Parent=$parentId;Sampled=1", $newHeader);
     }
 }

--- a/tests/TraceTest.php
+++ b/tests/TraceTest.php
@@ -153,9 +153,11 @@ class TraceTest extends TestCase
 
         $trace = new Trace();
         $trace->setTraceHeader("Root=$traceId;Sampled=1;Parent=$parentId");
+        $segment = $trace->getCurrentSegment();
+        $parentIdToCheck = $segment->getId();
 
         $newHeader = $trace->getAmazonTraceHeader();
         $this->assertStringStartsWith("Root=", $newHeader);
-        $this->assertStringEndsWith(";Parent=$parentId;Sampled=1", $newHeader);
+        $this->assertStringEndsWith(";Parent=$parentIdToCheck;Sampled=1", $newHeader);
     }
 }


### PR DESCRIPTION
I discovered that AWS Segments need to use a parent id from a segment and not the trace id.